### PR TITLE
Make routes for available cinemas and genres

### DIFF
--- a/backend/src/main/kotlin/com/rotadacultura/model/Movie.kt
+++ b/backend/src/main/kotlin/com/rotadacultura/model/Movie.kt
@@ -6,15 +6,15 @@ import java.io.File
 
 @Serializable
 data class Movie(
-    val name: String,
     val id: String,
+    val name: String,
     val url: String,
     // uses snake case because of JSON formating
     val img_url: String,
     val rating: String,
     val duration: String,
     val synopsis: String,
-    val genre: List<String>,
+    val categories: List<String>,
 ) {
     companion object {
         // List to store all movies' data

--- a/backend/src/main/kotlin/com/rotadacultura/model/Session.kt
+++ b/backend/src/main/kotlin/com/rotadacultura/model/Session.kt
@@ -1,0 +1,33 @@
+package com.rotadacultura.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
+import java.io.File
+
+@Serializable
+data class Session(
+    val cinema: String,
+    val movie: String,
+    val date: String,
+    val time: String,
+    val categories: List<String>
+) {
+    companion object {
+        // List to store all sessions' data
+        private val sessionsData: List<Session> = Json.decodeFromString(
+            File(Cinema::class.java.classLoader.getResource("sessions.json")!!.toURI()).readText()
+        )
+
+        fun new(cinema: String, date: String, time: String): Session? {
+            return sessionsData.find {
+                it.cinema == cinema &&
+                it.date == date &&
+                it.time == time
+            }
+        }
+
+        fun getSessionsData(): List<Session> {
+            return sessionsData
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/rotadacultura/routes/MovieRoutes.kt
+++ b/backend/src/main/kotlin/com/rotadacultura/routes/MovieRoutes.kt
@@ -1,6 +1,7 @@
 package com.rotadacultura.routes
 
 import com.rotadacultura.model.Movie
+import com.rotadacultura.model.Session
 import io.ktor.server.response.*
 import io.ktor.http.*
 import io.ktor.server.routing.*
@@ -14,6 +15,31 @@ fun Route.movieRouting() {
                 call.respond(mapOf("movies" to movies))
             } catch (ex: Exception) {
                 call.respond(HttpStatusCode.InternalServerError, "Error gathering movies on display information: ${ex.message}")
+            }
+        }
+        get("{movie_id}/available-cinemas") {
+            try {
+                val movieId = call.parameters["movie_id"]!!.toString()
+                val sessions = Session.getSessionsData()
+                val cinemas = sessions
+                    .filter {it.movie == movieId}
+                    .map {it.cinema}
+                    .distinct()
+                call.respond(mapOf("available_cinemas" to cinemas))
+            } catch (ex: Exception) {
+                call.respond(HttpStatusCode.InternalServerError, "Error gathering available cinemas: ${ex.message}")
+            }
+        }
+        get("genres") {
+            try {
+                val movies = Movie.getMoviesData()
+                val genres = movies
+                    .flatMap { it.categories }
+                    .filter { it.isNotEmpty() }
+                    .distinct()
+                call.respond(mapOf("genres" to genres))
+            } catch (ex: Exception) {
+                call.respond(HttpStatusCode.InternalServerError, "Error gathering movie genres: ${ex.message}")
             }
         }
     }

--- a/backend/src/main/kotlin/com/rotadacultura/routes/MovieRoutes.kt
+++ b/backend/src/main/kotlin/com/rotadacultura/routes/MovieRoutes.kt
@@ -25,7 +25,7 @@ fun Route.movieRouting() {
                     .filter {it.movie == movieId}
                     .map {it.cinema}
                     .distinct()
-                call.respond(mapOf("available_cinemas" to cinemas))
+                call.respond(mapOf("available-cinemas" to cinemas))
             } catch (ex: Exception) {
                 call.respond(HttpStatusCode.InternalServerError, "Error gathering available cinemas: ${ex.message}")
             }

--- a/backend/src/test/kotlin/MovieRoutesTest.kt
+++ b/backend/src/test/kotlin/MovieRoutesTest.kt
@@ -1,15 +1,16 @@
 package com.rotadacultura
 
-import com.rotadacultura.model.Movie
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import org.junit.Test
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class MovieRoutesTest {
     @Test
@@ -20,35 +21,52 @@ class MovieRoutesTest {
 
         val response = client.get("/movie")
         val body = response.bodyAsText()
+        val json = Json.parseToJsonElement(body).jsonObject
+        val movies = json["movies"]!!.jsonArray
 
         assertEquals(HttpStatusCode.OK, response.status)
-        assertContains(body, "Divertida Mente 2")
+        assertNotNull(movies)
+        assertTrue(movies.isNotEmpty())
+        assertNotNull(movies[0].jsonObject["name"])
+        assertNotNull(movies[0].jsonObject["id"])
+        assertNotNull(movies[0].jsonObject["url"])
+        assertNotNull(movies[0].jsonObject["img_url"])
+        assertNotNull(movies[0].jsonObject["rating"])
+        assertNotNull(movies[0].jsonObject["duration"])
+        assertNotNull(movies[0].jsonObject["synopsis"])
+        assertNotNull(movies[0].jsonObject["categories"])
     }
 
     @Test
-    fun cinemaIsCreatedOnMovieGetRequest() = testApplication {
+    fun listOfGenresIsCorrectlyReturned() = testApplication {
         application {
             module()
         }
 
-        val response = client.get("/movie")
-        println(response.bodyAsText())
+        val response = client.get("/movie/genres")
+        val body = response.bodyAsText()
+        val json = Json.parseToJsonElement(body).jsonObject
+        val genres = json["genres"]!!.jsonArray
+
+
+        assertNotNull(genres)
+        assertTrue(genres.isNotEmpty())
         assertEquals(HttpStatusCode.OK, response.status)
+    }
 
-        // Deserialize response body to access the availableCinemas field
-        val json = Json { ignoreUnknownKeys = true }
-        val movieResponse = json.decodeFromString<Map<String, List<Movie>>>(response.bodyAsText())
-        val movies = movieResponse["movies"] ?: emptyList()
-        val firstMovie = movies.firstOrNull()
-        assertNotNull(firstMovie)
+    @Test
+    fun listOfAvailableCinemasIsCorrectlyReturned() = testApplication {
+        application {
+            module()
+        }
 
-        val availableCinemas = firstMovie.availableCinemas
+        val response = client.get("/movie/gladiador-ii/available-cinemas")
+        val body = response.bodyAsText()
+        val json = Json.parseToJsonElement(body).jsonObject
+        val availableCinemas = json["available-cinemas"]!!.jsonArray
+
         assertNotNull(availableCinemas)
-
-        val cinema = availableCinemas.firstOrNull { it.name == "Cinemark" }
-        assertNotNull(cinema)
-        assertEquals("Cinemark", cinema.name)
-        assertEquals(5.23587, cinema.latitude)
-        assertEquals(23.18275, cinema.longitude)
+        assertTrue(availableCinemas.isNotEmpty())
+        assertEquals(HttpStatusCode.OK, response.status)
     }
 }


### PR DESCRIPTION
Now, there are two new routes:

- "/movie/{movie_id}/available_cinemas": returns a JSON with all cinemas displaying the movie with id {movie_id}.
- "/movie/genres": returns a JSON with all genres possible, enabling further filtering by genre.